### PR TITLE
upgrade libloading dep to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-libloading = "0.5"
+libloading = "0.7"
 lazy_static = "1.0"
 failure = "0.1"
 libc = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@
 //!
 //! ``` toml
 //! [dependencies]
-//! rustc-llvm-proxy = "0.1"
+//! rustc-llvm-proxy = "0.4"
 //! ```
 //!
 //! ``` rust
@@ -67,12 +67,14 @@ lazy_static! {
             }
         };
 
-        match Library::new(lib_path) {
-            Ok(path) => path,
+        unsafe {
+            match Library::new(lib_path) {
+                Ok(path) => path,
 
-            Err(error) => {
-                eprintln!("Unable to open LLVM shared lib: {}", error);
-                panic!();
+                Err(error) => {
+                    eprintln!("Unable to open LLVM shared lib: {}", error);
+                    panic!();
+                }
             }
         }
     };


### PR DESCRIPTION
PR upgrades the `libloading` dependency from 0.5 to 0.7. ` libloading::Library::new` per the docs [1] needs to be wrapped in `unsafe` block.

[1] https://docs.rs/libloading/latest/libloading/#usage