### PR TITLE
path: Add `LLVM_SYS_150_PREFIX` values to possible directories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ lazy_static = "1.0"
 failure = "0.1"
 libc = "0.2"
 llvm-sys = { version = "150", features = ["no-llvm-linking", "disable-alltargets-init"] }
+regex = "1"
 
 [build-dependencies]
 cargo_metadata = "0.8"

--- a/build.rs
+++ b/build.rs
@@ -14,7 +14,7 @@ fn main() {
     // Dummy declarations for RLS.
     if std::env::var("CARGO").unwrap_or_default().ends_with("rls") {
         llvm::Generator::default()
-            .write_declarations(&format!("{}/llvm_gen.rs", out_dir))
+            .write_declarations(&format!("{out_dir}/llvm_gen.rs"))
             .expect("Unable to write generated LLVM declarations");
 
         return;
@@ -25,7 +25,7 @@ fn main() {
     llvm::Generator::default()
         .parse_llvm_sys_crate()
         .expect("Unable to parse 'llvm-sys' crate")
-        .write_declarations(&format!("{}/llvm_gen.rs", out_dir))
+        .write_declarations(&format!("{out_dir}/llvm_gen.rs"))
         .expect("Unable to write generated LLVM declarations");
 
     // Workaround for `cargo package`

--- a/src/init.rs
+++ b/src/init.rs
@@ -42,7 +42,7 @@ fn get_native_backend() -> String {
 
 unsafe fn init_all(postfix: &str) {
     for backend in POSSIBLE_BACKENDS {
-        let name = format!("LLVMInitialize{}{}", backend, postfix);
+        let name = format!("LLVMInitialize{backend}{postfix}");
         if let Ok(entrypoint) = SHARED_LIB.get::<unsafe extern "C" fn()>(name.as_bytes()) {
             entrypoint();
         }
@@ -72,7 +72,7 @@ pub unsafe extern "C" fn LLVM_InitializeAllAsmPrinters() {
 
 unsafe fn init_native(postfix: &str) -> LLVMBool {
     let backend = get_native_backend();
-    let name = format!("LLVMInitialize{}{}", backend, postfix);
+    let name = format!("LLVMInitialize{backend}{postfix}");
     if let Ok(entrypoint) = SHARED_LIB.get::<unsafe extern "C" fn()>(name.as_bytes()) {
         entrypoint();
         0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ lazy_static! {
             Ok(path) => path,
 
             Err(error) => {
-                eprintln!("{}", error);
+                eprintln!("{error}");
                 panic!();
             }
         };
@@ -72,7 +72,7 @@ lazy_static! {
                 Ok(path) => path,
 
                 Err(error) => {
-                    eprintln!("Unable to open LLVM shared lib: {}", error);
+                    eprintln!("Unable to open LLVM shared lib: {error}");
                     panic!();
                 }
             }

--- a/src/path.rs
+++ b/src/path.rs
@@ -4,6 +4,11 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use failure::Error;
+use regex::Regex;
+
+lazy_static! {
+    static ref RE: Regex = Regex::new(r"^libLLVM.*\.so").unwrap();
+}
 
 pub fn find_lib_path() -> Result<PathBuf, Error> {
     let directories = collect_possible_directories();
@@ -31,6 +36,15 @@ pub fn find_lib_path() -> Result<PathBuf, Error> {
 fn collect_possible_directories() -> Vec<PathBuf> {
     let mut paths = vec![];
     let separator = if cfg!(windows) { ';' } else { ':' };
+
+    if let Ok(build_paths) = env::var("LLVM_SYS_150_PREFIX") {
+        for item in build_paths.split(separator) {
+            let mut possible_path = PathBuf::from(item);
+
+            possible_path.push("lib");
+            paths.push(possible_path);
+        }
+    }
 
     if let Ok(lib_paths) = env::var("LD_LIBRARY_PATH") {
         for item in lib_paths.split(separator) {
@@ -61,9 +75,29 @@ fn find_library_in_directory(directory: &Path) -> Option<PathBuf> {
     match read_dir(directory) {
         Ok(files) => files
             .filter_map(Result::ok)
-            .find(|file| file.file_name().to_string_lossy().starts_with("libLLVM"))
+            .find(|file| RE.is_match(file.file_name().to_string_lossy().as_ref()))
             .map(|file| file.path()),
 
         Err(_) => None,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_llvm_lib_regex() {
+        // Possible names in packages.
+        assert!(RE.is_match("libLLVM.so"));
+        assert!(RE.is_match("libLLVM.so.15"));
+        assert!(RE.is_match("libLLVM.so.15.0"));
+        assert!(RE.is_match("libLLVM.so.15.0.6"));
+        // Possible names in Rust toolchains.
+        assert!(RE.is_match("libLLVM-15-rust-1.66.0-stable.so"));
+        assert!(RE.is_match("libLLVM-15-rust-1.67.0-beta.so"));
+        assert!(RE.is_match("libLLVM-15-rust-1.68.0-nightly.so"));
+        // Name in local build.
+        assert!(RE.is_match("libLLVM-15.so"));
     }
 }


### PR DESCRIPTION
Using `LLVM_SYS_150_PREFIX` is comfortable when testing with locally built LLVM, it removes the necessity of installing it. This is the same enviroment variable that llvm-sys crate uses.

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>