### PR TITLE
change the version in the README example to "0.6"

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Then all you need to do is to include the crate into your project:
 
 ``` toml
 [dependencies]
-aya-rustc-llvm-proxy = "0.3"
+aya-rustc-llvm-proxy = "0.6"
 ```
 
 ``` rust


### PR DESCRIPTION
Moved the version in README up in the expectation that the next version/tag will be `v0.6.0`.