### PR TITLE
Add LLVMPassBuilder proxy

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -78,6 +78,7 @@ mod llvm {
         "target.rs",
         "target_machine.rs",
         "transforms/ipo.rs",
+        "transforms/pass_builder.rs",
         "transforms/pass_manager_builder.rs",
         "transforms/scalar.rs",
         "transforms/vectorize.rs",

--- a/build.rs
+++ b/build.rs
@@ -58,14 +58,17 @@ mod llvm {
     use super::*;
 
     const LLVM_SOURCES: &[&str] = &[
-        "core.rs",
-        "linker.rs",
+        "analysis.rs",
         "bit_reader.rs",
         "bit_writer.rs",
-        "ir_reader.rs",
+        "core.rs",
+        "debuginfo.rs",
         "disassembler.rs",
         "error_handling.rs",
+        "execution_engine.rs",
         "initialization.rs",
+        "ir_reader.rs",
+        "linker.rs",
         "lto.rs",
         "object.rs",
         "orc2/ee.rs",
@@ -78,9 +81,6 @@ mod llvm {
         "transforms/pass_manager_builder.rs",
         "transforms/scalar.rs",
         "transforms/vectorize.rs",
-        "debuginfo.rs",
-        "analysis.rs",
-        "execution_engine.rs",
     ];
 
     const INIT_MACROS: &[&str] = &[

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,7 @@ pub mod proxy {
     use llvm_sys::prelude::*;
     use llvm_sys::target::*;
     use llvm_sys::target_machine::*;
+    use llvm_sys::transforms::pass_builder::*;
     use llvm_sys::transforms::pass_manager_builder::*;
     use llvm_sys::*;
 


### PR DESCRIPTION
This allows us to use the new pass manager in bpf-linker.
