### PR TITLE
Generate proxies for all of llvm-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-libloading = "0.8"
+libloading = "0.8.0"
 lazy_static = "1.0"
 failure = "0.1"
 libc = "0.2"
@@ -21,7 +21,8 @@ llvm-sys = { version = "160", features = [
 ] }
 
 [build-dependencies]
-cargo_metadata = "0.15"
+cargo_metadata = "0.15.4"
 failure = "0.1"
-quote = "1.0"
-syn = { version = "2.0", features = ["full"] }
+prettyplease = "0.2.10"
+quote = "1.0.29"
+syn = { version = "2.0.26", features = ["full"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,48 +80,9 @@ lazy_static! {
     };
 }
 
-/// Commonly used LLVM CAPI symbols with dynamic resolving
+/// LLVM C-API symbols with dynamic resolving.
 pub mod proxy {
     use super::SHARED_LIB;
-
-    use llvm_sys::analysis::*;
-    use llvm_sys::debuginfo::*;
-    use llvm_sys::disassembler::*;
-    use llvm_sys::error::*;
-    use llvm_sys::error_handling::*;
-    use llvm_sys::execution_engine::*;
-    use llvm_sys::lto::*;
-    use llvm_sys::object::*;
-    use llvm_sys::orc2::ee::*;
-    use llvm_sys::orc2::lljit::*;
-    use llvm_sys::orc2::*;
-    use llvm_sys::prelude::*;
-    use llvm_sys::target::*;
-    use llvm_sys::target_machine::*;
-    use llvm_sys::transforms::pass_builder::*;
-    use llvm_sys::transforms::pass_manager_builder::*;
-    use llvm_sys::*;
-
-    macro_rules! create_proxy {
-        ($name:ident ; $ret_ty:ty ; $($arg:ident : $arg_ty:ty),*) => {
-            #[no_mangle]
-            pub unsafe extern "C" fn $name($($arg: $arg_ty),*) -> $ret_ty {
-                let entrypoint = {
-                    SHARED_LIB
-                        .get::<unsafe extern "C" fn($($arg: $arg_ty),*) -> $ret_ty>(stringify!($name).as_bytes())
-                };
-
-                match entrypoint {
-                    Ok(entrypoint) => entrypoint($($arg),*),
-
-                    Err(_) => {
-                        eprintln!("Unable to find symbol '{}' in the LLVM shared lib", stringify!($name));
-                        panic!();
-                    }
-                }
-            }
-        };
-    }
 
     include!(concat!(env!("OUT_DIR"), "/llvm_gen.rs"));
 }


### PR DESCRIPTION
This avoids having to manually list sources. This exposed a duplicate
symbol declaration in llvm-sys; see https://reviews.llvm.org/D155402.
