### PR TITLE
.github: add scheduled build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,15 @@ name: Build
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+
   pull_request:
-    branches: [main]
+    branches:
+      - main
+
+  schedule:
+    - cron: 00 4 * * *
 
 jobs:
   ci:


### PR DESCRIPTION
We've been seeing failures in bpf-linker that seems related to this crate. Add a daily run so we find out about issues eagerly.