### PR TITLE
Fix build in rust 1.79

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aya-rustc-llvm-proxy"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Alessandro Decina <alessandro.d@gmail.com>"]
 description = "Dynamically proxy LLVM calls into Rust own shared library"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,5 @@ anyhow = "1.0.72"
 cargo_metadata = "0.18.0"
 prettyplease = "0.2.10"
 quote = "1.0.29"
+rustversion = "1.0"
 syn = { version = "2.0.26", features = ["full"] }

--- a/build.rs
+++ b/build.rs
@@ -59,6 +59,14 @@ mod llvm {
 
     impl Generator {
         pub fn parse_llvm_sys_crate(&mut self) -> Result<&mut Self, Error> {
+            // See https://github.com/rust-lang/cargo/pull/12783.
+
+            #[rustversion::before(1.79)]
+            const LLVM_SYS_CRATE_TARGET: &str = "llvm-sys";
+
+            #[rustversion::since(1.79)]
+            const LLVM_SYS_CRATE_TARGET: &str = "llvm_sys";
+
             let metadata = MetadataCommand::new()
                 .exec()
                 .context("Unable to get crate metadata")?;
@@ -72,7 +80,7 @@ mod llvm {
                             targets
                                 .into_iter()
                                 .find_map(|Target { name, src_path, .. }| {
-                                    (name == "llvm-sys").then_some(src_path)
+                                    (name == LLVM_SYS_CRATE_TARGET).then_some(src_path)
                                 })
                         })
                         .flatten()


### PR DESCRIPTION
- **Look for underscored name in rust 1.79**
- **chore: bump version**
