### PR TITLE
chore: Update LLVM to 19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 once_cell = "1.18.0"
 libc = "0.2"
 libloading = "0.8.0"
-llvm-sys = { version = "181.0.0", features = [
+llvm-sys = { version = "^191.0.0-rc1", features = [
     "no-llvm-linking",
     "disable-alltargets-init",
 ] }


### PR DESCRIPTION
Latest Rust nightly switched to LLVM 19, so we need to update in order to make the proxy work.